### PR TITLE
Break textlines in pdf if too long

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/SøknadTextFormatter.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/SøknadTextFormatter.java
@@ -96,7 +96,7 @@ public class SøknadTextFormatter {
     public String periode(ÅpenPeriode periode) {
         StringBuilder sb = new StringBuilder("fra og med " + dato(periode.getFom()));
         if (periode.getTom() != null) {
-            sb.append(periode.getTom() != null ? " til og med" + dato(periode.getTom()) : " pågående");
+            sb.append(periode.getTom() != null ? " til og med " + dato(periode.getTom()) : " pågående");
         }
         return sb.toString();
     }

--- a/src/test/java/no/nav/foreldrepenger/mottak/domain/foreldrepenger/ForeldrepengerTestUtils.java
+++ b/src/test/java/no/nav/foreldrepenger/mottak/domain/foreldrepenger/ForeldrepengerTestUtils.java
@@ -114,7 +114,7 @@ public class ForeldrepengerTestUtils {
         return new Frilans(åpenPeriode(true), true, true,
                 newArrayList(
                         new FrilansOppdrag("fattern", åpenPeriode(true)),
-                        new FrilansOppdrag("den andre bror min", åpenPeriode(true)),
+                        new FrilansOppdrag("den andre bror min og samtidig en fryktelig lang tekst som straks må bryte over til ny linje", åpenPeriode(true)),
                         new FrilansOppdrag("den tredje bror min", åpenPeriode(true)),
                         new FrilansOppdrag("den fjerde ebror min", åpenPeriode(true)),
                         new FrilansOppdrag("far min", åpenPeriode(true))),
@@ -169,7 +169,7 @@ public class ForeldrepengerTestUtils {
                 .næringsinntektBrutto(100_000)
                 .orgName("Utenlandsk org")
                 .virksomhetsTyper(Collections.singletonList(FISKE))
-                .beskrivelseEndring("Endringer skjer fort i verdens største land (utlandet)")
+                .beskrivelseEndring("Endringer skjer fort i verdens største land (utlandet) og ikke minst skjer det mye med linjebryting")
                 .nærRelasjon(true)
                 .endringsDato(LocalDate.now()).build();
     }

--- a/src/test/java/no/nav/foreldrepenger/mottak/innsending/pdf/ForeldrepengerPDFGeneratorTest.java
+++ b/src/test/java/no/nav/foreldrepenger/mottak/innsending/pdf/ForeldrepengerPDFGeneratorTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.mottak.pdf;
+package no.nav.foreldrepenger.mottak.innsending.pdf;
 
 import static no.nav.foreldrepenger.mottak.domain.felles.TestUtils.hasPdfSignature;
 import static no.nav.foreldrepenger.mottak.domain.felles.TestUtils.person;

--- a/src/test/java/no/nav/foreldrepenger/mottak/innsending/pdf/PDFElementRendererTest.java
+++ b/src/test/java/no/nav/foreldrepenger/mottak/innsending/pdf/PDFElementRendererTest.java
@@ -1,0 +1,32 @@
+package no.nav.foreldrepenger.mottak.innsending.pdf;
+
+import org.junit.Test;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class PDFElementRendererTest {
+
+    @Test
+    public void softLineBreakOnSpace() {
+        List<String> lines = splitLine("test1 test2", 8);
+        assertEquals("test1", lines.get(0));
+        assertEquals("test2", lines.get(1));
+    }
+
+    @Test
+    public void hardLineBreak() {
+        List<String> linesA = splitLine("test1 test2test3", 10);
+        assertEquals("test1", linesA.get(0));
+        assertEquals("test2test3", linesA.get(1));
+
+        List<String> linesB = splitLine("test1 test2test3test4", 17);
+        assertEquals("test1 test2test3t-", linesB.get(0));
+        assertEquals("est4", linesB.get(1));
+    }
+
+    private List<String> splitLine(String str, int maxLength) {
+        PDFElementRenderer renderer = new PDFElementRenderer();
+        return renderer.splitLineIfNecessary(str, maxLength);
+    }
+
+}


### PR DESCRIPTION
This introduces line breaking in PDF when text length exceeds available space (changes in PDFELementRenderer).

In addition: 

- moves ForeldrePengerPDFGeneratorTest 
- fixes missing space in periode in SøknadTextFormatter.