### PR TITLE
Font concurrency fix

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwareCos.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwareCos.java
@@ -7,20 +7,20 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 
 public class FontAwareCos {
-    final PDFont REGULARFONT;
-    final PDFont HEADINGFONT;
-    final int REGULARFONTHEIGHT;
-    final int HEADINGFONTHEIGHT;
+    final PDFont fontRegular;
+    final PDFont fontHeading;
+    final int fontHeightRegular;
+    final int fontHeightHeading;
     final int REGULARFONTSIZE = 11;
     private final PDPageContentStream cos;
     private final int HEADINGFONTSIZE = 12;
 
     public FontAwareCos(FontAwarePDDocument doc, PDPage page) throws IOException {
         this.cos = new PDPageContentStream(doc, page);
-        this.REGULARFONT = FontAwarePDDocument.REGULARFONT;
-        this.HEADINGFONT = FontAwarePDDocument.BOLDFONT;
-        this.REGULARFONTHEIGHT = fontHeight(REGULARFONT, REGULARFONTSIZE);
-        this.HEADINGFONTHEIGHT = fontHeight(HEADINGFONT, HEADINGFONTSIZE);
+        this.fontRegular = doc.getRegularFont();
+        this.fontHeading = doc.getBoldFont();
+        this.fontHeightRegular = fontHeight(fontRegular, REGULARFONTSIZE);
+        this.fontHeightHeading = fontHeight(fontHeading, HEADINGFONTSIZE);
     }
 
     private static int fontHeight(PDFont font, int size) {
@@ -28,11 +28,11 @@ public class FontAwareCos {
     }
 
     public void useRegularFont() throws IOException {
-        setFont(REGULARFONT, REGULARFONTSIZE);
+        setFont(fontRegular, REGULARFONTSIZE);
     }
 
     public void useHeadingFont() throws IOException {
-        setFont(HEADINGFONT, HEADINGFONTSIZE);
+        setFont(fontHeading, HEADINGFONTSIZE);
     }
 
     public PDPageContentStream getCos() {
@@ -64,7 +64,7 @@ public class FontAwareCos {
     }
 
     public float headingTextWidth(String string) throws IOException {
-        return textWidth(string, HEADINGFONT, HEADINGFONTSIZE);
+        return textWidth(string, fontHeading, HEADINGFONTSIZE);
     }
 
     private static float textWidth(String string, PDFont font, int fontSize) throws IOException {

--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
@@ -19,12 +19,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 
-
 public class FontAwarePDDocument extends PDDocument {
     private static final Logger LOG = LoggerFactory.getLogger(FontAwarePDDocument.class);
 
     private static final Resource regularFontResource = streamFra("/pdf/NotoSans-Regular.ttf");
     private static final Resource boldFontResource = streamFra("/pdf/NotoSans-Bold.ttf");
+    private static final Resource iccProfile = streamFra("/pdf/sRGB.icc");
 
     private PDFont regularFont;
     private PDFont boldFont;
@@ -75,7 +75,7 @@ public class FontAwarePDDocument extends PDDocument {
             metadata.importXMPMetadata(baos.toByteArray());
             doc.getDocumentCatalog().setMetadata(metadata);
 
-            InputStream colorProfile = new ClassPathResource("/pdf/sRGB.icc").getInputStream();
+            InputStream colorProfile = iccProfile.getInputStream();
             PDOutputIntent intent = new PDOutputIntent(doc, colorProfile);
             intent.setInfo("sRGB IEC61966-2.1");
             intent.setOutputCondition("sRGB IEC61966-2.1");

--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
@@ -22,9 +22,9 @@ import java.io.InputStream;
 public class FontAwarePDDocument extends PDDocument {
     private static final Logger LOG = LoggerFactory.getLogger(FontAwarePDDocument.class);
 
-    private static final Resource regularFontResource = streamFra("/pdf/NotoSans-Regular.ttf");
-    private static final Resource boldFontResource = streamFra("/pdf/NotoSans-Bold.ttf");
-    private static final Resource iccProfile = streamFra("/pdf/sRGB.icc");
+    private static final Resource regularFontResource = ressursFra("/pdf/NotoSans-Regular.ttf");
+    private static final Resource boldFontResource = ressursFra("/pdf/NotoSans-Bold.ttf");
+    private static final Resource iccProfile = ressursFra("/pdf/sRGB.icc");
 
     private PDFont regularFont;
     private PDFont boldFont;
@@ -35,7 +35,7 @@ public class FontAwarePDDocument extends PDDocument {
         setPdfMetadata(this);
     }
 
-    private static Resource streamFra(String s) {
+    private static Resource ressursFra(String s) {
         return new ClassPathResource(s);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/FontAwarePDDocument.java
@@ -1,10 +1,8 @@
 package no.nav.foreldrepenger.mottak.innsending.pdf;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDMetadata;
+import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.graphics.color.PDOutputIntent;
 import org.apache.xmpbox.XMPMetadata;
@@ -14,16 +12,48 @@ import org.apache.xmpbox.xml.XmpSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+
 
 public class FontAwarePDDocument extends PDDocument {
-    public static PDType0Font REGULARFONT;
-    public static PDType0Font BOLDFONT;
     private static final Logger LOG = LoggerFactory.getLogger(FontAwarePDDocument.class);
 
+    private static final Resource regularFontResource = streamFra("/pdf/NotoSans-Regular.ttf");
+    private static final Resource boldFontResource = streamFra("/pdf/NotoSans-Bold.ttf");
+
+    private PDFont regularFont;
+    private PDFont boldFont;
+
     public FontAwarePDDocument() throws IOException {
-        BOLDFONT = PDType0Font.load(this, new ClassPathResource("/pdf/NotoSans-Bold.ttf").getInputStream());
-        REGULARFONT = PDType0Font.load(this, new ClassPathResource("/pdf/NotoSans-Regular.ttf").getInputStream());
+        regularFont = load(regularFontResource);
+        boldFont = load(boldFontResource);
         setPdfMetadata(this);
+    }
+
+    private static Resource streamFra(String s) {
+        return new ClassPathResource(s);
+    }
+
+    public PDFont getRegularFont() {
+        return regularFont;
+    }
+
+    public PDFont getBoldFont() {
+        return boldFont;
+    }
+
+    private synchronized PDFont load(Resource res) throws IOException {
+        try (InputStream is = res.getInputStream()) {
+            return PDType0Font.load(this, is);
+        } catch (IOException e) {
+            LOG.warn("Kunne ikke lese InputStream under lasting av fonter", e);
+            throw e;
+        }
     }
 
     private static void setPdfMetadata(PDDocument doc) throws IOException {
@@ -45,7 +75,8 @@ public class FontAwarePDDocument extends PDDocument {
             metadata.importXMPMetadata(baos.toByteArray());
             doc.getDocumentCatalog().setMetadata(metadata);
 
-            PDOutputIntent intent = new PDOutputIntent(doc, new ClassPathResource("/pdf/sRGB.icc").getInputStream());
+            InputStream colorProfile = new ClassPathResource("/pdf/sRGB.icc").getInputStream();
+            PDOutputIntent intent = new PDOutputIntent(doc, colorProfile);
             intent.setInfo("sRGB IEC61966-2.1");
             intent.setOutputCondition("sRGB IEC61966-2.1");
             intent.setOutputConditionIdentifier("sRGB IEC61966-2.1");

--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/PDFElementRenderer.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/PDFElementRenderer.java
@@ -76,20 +76,20 @@ public class PDFElementRenderer {
 
     public float addLineOfRegularText(int marginOffset, String line, FontAwareCos cos, float startY)
             throws IOException {
-        String encodableLine = normalizeAndRemoveNonencodableChars(line, cos.REGULARFONT);
+        String encodableLine = normalizeAndRemoveNonencodableChars(line, cos.fontRegular);
         List<String> lines = splitLineIfNecessary(
                 encodableLine,
-                characterLimitInCos(cos.REGULARFONT, cos.REGULARFONTSIZE, marginOffset));
+                characterLimitInCos(cos.fontRegular, cos.REGULARFONTSIZE, marginOffset));
         int lineNumber = 0;
         for (String singleLine : lines) {
             cos.beginText();
             cos.useRegularFont();
-            cos.newLineAtOffset(MARGIN + marginOffset, startY - lineNumber * cos.REGULARFONTHEIGHT);
+            cos.newLineAtOffset(MARGIN + marginOffset, startY - lineNumber * cos.fontHeightRegular);
             cos.showText(Optional.ofNullable(singleLine).orElse(""));
             cos.endText();
             lineNumber++;
         }
-        return cos.REGULARFONTHEIGHT * lines.size();
+        return cos.fontHeightRegular * lines.size();
     }
 
     String normalizeAndRemoveNonencodableChars(String str, PDFont font) throws IOException {
@@ -173,9 +173,9 @@ public class PDFElementRenderer {
         float titleWidth = cos.headingTextWidth(heading);
         float startX = (MEDIABOX.getWidth() - titleWidth) / 2;
         cos.newLineAtOffset(startX, startY);
-        cos.showText(normalizeAndRemoveNonencodableChars(heading, cos.HEADINGFONT));
+        cos.showText(normalizeAndRemoveNonencodableChars(heading, cos.fontHeading));
         cos.endText();
-        return cos.HEADINGFONTHEIGHT;
+        return cos.fontHeightHeading;
     }
 
     public float addCenteredHeadings(List<String> headings, FontAwareCos cos, float startY) throws IOException {
@@ -193,7 +193,7 @@ public class PDFElementRenderer {
         cos.newLineAtOffset(startX, startY);
         cos.showText(heading);
         cos.endText();
-        return cos.HEADINGFONTHEIGHT;
+        return cos.fontHeightHeading;
     }
 
     public float addDividerLine(FontAwareCos cos, float startY) throws IOException {


### PR DESCRIPTION
Endringer:

- Laster font som Resource som brukes av syncronized load-metode for å unngå problemer med concurrency ved fontlasting
- endret last av icc-profil til å bruke ned nye streamFra-metoden, men her er lasten ikke synchronized ettersom vi ikke er så opptatt av at metadata til pdf går ok