### PR TITLE
Sett timeouts for resttemplate som brukes av DefaultOauth2HttpClient

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/mottak/http/TokenClientRestTemplateConfiguration.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/http/TokenClientRestTemplateConfiguration.java
@@ -1,0 +1,23 @@
+package no.nav.foreldrepenger.mottak.http;
+
+import org.springframework.boot.autoconfigure.web.client.RestTemplateBuilderConfigurer;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration(proxyBeanMethods = false)
+public class TokenClientRestTemplateConfiguration {
+
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+
+    // Konfigurererer timeouts for DefaultOAuth2HttpClient fra token-client-spring
+    @Bean
+    public RestTemplateBuilder resttemplateBuilderCustomizer(RestTemplateBuilderConfigurer configurer) {
+        return configurer.configure(new RestTemplateBuilder())
+            .setReadTimeout(READ_TIMEOUT)
+            .setConnectTimeout(CONNECT_TIMEOUT);
+    }
+}


### PR DESCRIPTION
Default resttemplate har ikke timeout-verdier satt. Kan derfor oppleve at kall mot tokenveksling henger. 
Konfigurerer her RestTemplateBuilder med timeout med sikte på kun tokenveksling.

Noen loggede EofException/broken pipe skyldes antakelig heng mot tokenveksling.