### PR TITLE
fix: i pdf, returner y også for automatisk vedlegg

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/ForeldrepengeInfoRenderer.java
+++ b/src/main/java/no/nav/foreldrepenger/mottak/innsending/pdf/ForeldrepengeInfoRenderer.java
@@ -372,7 +372,7 @@ public class ForeldrepengeInfoRenderer extends FellesSøknadInfoRenderer {
         List<VedleggReferanse> vedleggRefs = uttak.getVedlegg();
 
         if (skalRenderAutomatiskVedlegg(uttak, brukerRolle)) {
-            renderAutomatiskVedlegg(cos, y);
+            return renderAutomatiskVedlegg(cos, y);
         }
         return renderVedlegg(vedlegg, vedleggRefs, keyIfAnnet, cos, y);
     }
@@ -396,7 +396,7 @@ public class ForeldrepengeInfoRenderer extends FellesSøknadInfoRenderer {
                                                 FontAwareCos cos,
                                                 float y) throws IOException {
         if (skalRenderAutomatiskVedlegg(gradert, rolle)) {
-            renderAutomatiskVedlegg(cos, y);
+            return renderAutomatiskVedlegg(cos, y);
         }
         return renderVedlegg(vedlegg, gradert.getVedlegg(), DOKUMENTASJON, cos, y);
     }


### PR DESCRIPTION
Etter endring:

<img width="561" alt="Screenshot 2025-05-12 at 13 57 57" src="https://github.com/user-attachments/assets/26a30295-3c6c-45cb-8d21-a5457a5a1867" />

